### PR TITLE
Fix export text break

### DIFF
--- a/src/view/components/canvas/EditableLabel.jsx
+++ b/src/view/components/canvas/EditableLabel.jsx
@@ -4,7 +4,7 @@ import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import { DIAGRAM_ITEM_NAME_CHANGED } from '../../diagram/consts';
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles({
   nameInput: {
     width: '100%',
     border: 'none',
@@ -14,13 +14,13 @@ const useStyles = makeStyles(() => ({
     fontSize: 14,
     padding: '0px',
   },
-}));
-const useTypographyStyles = makeStyles(() => ({
-  root: (width) => ({
+});
+const useTypographyStyles = makeStyles({
+  root: ({ width }) => ({
     width, // workaround for https://github.com/bubkoo/html-to-image/issues/132
     pointerEvents: 'all',
   }),
-}));
+});
 const EditableLabel = ({
   label,
   width,
@@ -29,7 +29,7 @@ const EditableLabel = ({
   isItemSelected,
 }) => {
   const classes = useStyles();
-  const typographyStyles = useTypographyStyles(width);
+  const typographyStyles = useTypographyStyles({ width });
   const inputEl = useRef(null);
   const [isInEditMode, setIsInEditMode] = useState(false);
   const [currentLabel, setCurrentLabel] = useState('');

--- a/src/view/components/canvas/NodeContextPanel.jsx
+++ b/src/view/components/canvas/NodeContextPanel.jsx
@@ -19,17 +19,16 @@ import {
   DIAGRAM_NODE_EXPANDED,
 } from '../../diagram/consts';
 
-const useStyles = (width) =>
-  makeStyles({
-    panel: {
-      position: 'absolute',
-      top: 0,
-      left: width,
-    },
-  });
+const useStyles = makeStyles({
+  panel: ({ width }) => ({
+    position: 'absolute',
+    top: 0,
+    left: width,
+  }),
+});
 
 const NodeContextPanel = ({ node }) => {
-  const classes = useStyles(node.size.width)();
+  const classes = useStyles({ width: node.size.width });
   return (
     <Box className={classes.panel}>
       {node.isSelected() && !node.options.isExpanded && node.options.isParent && (

--- a/src/view/diagram/nodes/RadicalComposedNodeWidget.jsx
+++ b/src/view/diagram/nodes/RadicalComposedNodeWidget.jsx
@@ -12,7 +12,7 @@ import { getPortStyle } from '../helpers';
 import EditableLabel from '../../components/canvas/EditableLabel';
 import NodeContextPanel from '../../components/canvas/NodeContextPanel';
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles({
   smartPort: {
     width: '16px',
     height: '16px',
@@ -24,7 +24,7 @@ const useStyles = makeStyles(() => ({
     right: 15,
     bottom: 10,
   },
-}));
+});
 const RadicalComposedNodeWidget = ({
   node,
   engine,

--- a/src/view/diagram/nodes/RadicalComposedNodeWidget.test.jsx
+++ b/src/view/diagram/nodes/RadicalComposedNodeWidget.test.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import * as muiStyles from '@material-ui/core/styles';
+
+import RadicalComposedNodeWidget from './RadicalComposedNodeWidget';
+
+jest.mock('@material-ui/core/styles', () => {
+  const mock = jest.fn();
+  return {
+    makeStyles: () => mock,
+  };
+});
+
+describe('RadicalComposedNodeWidget', () => {
+  it('renders node title with given node width', async () => {
+    muiStyles.makeStyles().mockImplementation(() => ({}));
+    const nodeWidth = { width: '200px' };
+
+    const { getByRole } = render(
+      <RadicalComposedNodeWidget
+        node={{
+          size: {
+            ...nodeWidth,
+            height: '300px',
+          },
+          isSelected: () => false,
+          getPorts: () => ({}),
+          options: {},
+        }}
+        name="Gandalf"
+        isSelected={false}
+        isAsymmetric={false}
+        isExpanded={false}
+        engine={{}}
+      >
+        <div>test</div>
+      </RadicalComposedNodeWidget>
+    );
+
+    expect(getByRole('heading')).toBeDefined();
+    expect(muiStyles.makeStyles()).toHaveBeenCalledWith(nodeWidth);
+  });
+});


### PR DESCRIPTION
Fixes: https://github.com/Radical-Tools/Radical.Studio/issues/66

App:
![image](https://user-images.githubusercontent.com/9931428/125176998-ac9ba880-e1d8-11eb-97b3-b930ec9069f7.png)

Exported file:
![Default View (19)](https://user-images.githubusercontent.com/9931428/125177002-b45b4d00-e1d8-11eb-9afd-de7707e03c34.png)

Issue is somewhere inside `html-to-image` package, this fix should be treated like workaround and therefore deleted once fixed in source library.

Related issue: https://github.com/bubkoo/html-to-image/issues/132