### PR TITLE
Adding tooltip for Node and link description

### DIFF
--- a/.github/workflows/commit-validation.yml
+++ b/.github/workflows/commit-validation.yml
@@ -1,5 +1,5 @@
 name: Commit Validation
-on: [push, pull_request]
+on: push
 
 jobs:
   build:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radical-studio-mvp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "dependencies": {
     "@emotion/react": "11.7.0",

--- a/src/view/components/NodeContextPanel.jsx
+++ b/src/view/components/NodeContextPanel.jsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Box from '@material-ui/core/Box';
-import { Tooltip } from '@material-ui/core';
+import Tooltip from '@material-ui/core/Tooltip';
 import IconButton from '@material-ui/core/IconButton';
 import DeleteForeverRoundedIcon from '@material-ui/icons/DeleteForeverRounded';
 import ZoomInRoundedIcon from '@material-ui/icons/ZoomInRounded';

--- a/src/view/components/NodeDescriptionIcon.jsx
+++ b/src/view/components/NodeDescriptionIcon.jsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import Tooltip from '@material-ui/core/Tooltip';
+import VisibilityIcon from '@material-ui/icons/Visibility';
+import Typography from '@material-ui/core/Typography';
+import PropTypes from 'prop-types';
+
+const descriptionIconStyle = (isExpanded) => ({
+  color: isExpanded ? '#595959' : 'white',
+  position: 'absolute',
+  top: 10,
+  right: 10,
+});
+
+const NodeDescriptionIcon = ({ node }) => (
+  <Tooltip
+    title={
+      <div>
+        <Typography variant="subtitle1">Description:</Typography>
+        <div>
+          <Typography variant="caption">
+            {node.options.attributes?.description || '-'}
+          </Typography>
+        </div>
+        <Typography variant="subtitle1">Outgoing Relations:</Typography>
+        <div>
+          {node
+            .getLinks()
+            .filter(
+              (element) =>
+                element.getSourcePort().getParent().getID() === node.getID()
+            )
+            .map((element) => (
+              <div key={element.getID()}>
+                <Typography variant="subtitle2" display="block">
+                  {`${element.getOptions().name} - ${
+                    element.getTargetPort().getParent().getOptions().name
+                  }:`}
+                </Typography>
+                <Typography variant="caption" display="block">
+                  {element.getOptions().attributes?.description}
+                </Typography>
+              </div>
+            ))}
+        </div>
+      </div>
+    }
+    aria-label="description"
+    placement="right-start"
+    arrow
+  >
+    <VisibilityIcon sx={descriptionIconStyle(node.options.isExpanded)} />
+  </Tooltip>
+);
+
+NodeDescriptionIcon.propTypes = {
+  node: PropTypes.objectOf(PropTypes.any).isRequired,
+};
+
+export default NodeDescriptionIcon;

--- a/src/view/widgets/DiagramWidget/diagram/nodes/RadicalComposedNodeWidget.jsx
+++ b/src/view/widgets/DiagramWidget/diagram/nodes/RadicalComposedNodeWidget.jsx
@@ -1,17 +1,15 @@
 import React from 'react';
 import { PortWidget } from '@projectstorm/react-diagrams';
-import Tooltip from '@material-ui/core/Tooltip';
-import VisibilityIcon from '@material-ui/icons/Visibility';
 import Typography from '@material-ui/core/Typography';
 import AccountTreeIcon from '@material-ui/icons/AccountTree';
 import Box from '@material-ui/core/Box';
 import PropTypes from 'prop-types';
 import values from 'lodash/fp/values';
-
 import { getPortStyle } from '../helpers';
 import EditableLabel from '../../../../components/EditableLabel';
 import NodeContextPanel from '../../../../components/NodeContextPanel';
 import { getCanvasNode } from '../../../../../tests/getDataTestId';
+import NodeDescriptionIcon from '../../../../components/NodeDescriptionIcon';
 
 const composedIconStyle = {
   position: 'absolute',
@@ -25,12 +23,6 @@ const smartPortStyle = {
   height: '16px',
 };
 
-const descriptionIconStyle = (isExpanded) => ({
-  color: isExpanded ? '#595959' : 'white',
-  position: 'absolute',
-  top: 10,
-  right: 10,
-});
 const RadicalComposedNodeWidget = ({
   node,
   engine,
@@ -61,50 +53,7 @@ const RadicalComposedNodeWidget = ({
           top: isAsymmetric ? 20 : 0,
         }}
       >
-        {node.options.attributes?.description && (
-          <Tooltip
-            title={
-              <div>
-                <Typography variant="subtitle1">Description:</Typography>
-                <div>
-                  <Typography variant="caption">
-                    {node.options.attributes?.description}
-                  </Typography>
-                </div>
-                <Typography variant="subtitle1">Outgoing Relations:</Typography>
-                <div>
-                  {node
-                    .getLinks()
-                    .filter(
-                      (element) =>
-                        element.getSourcePort().getParent().getID() ===
-                        node.getID()
-                    )
-                    .map((element) => (
-                      <div key={element.getID()}>
-                        <Typography variant="subtitle2" display="block">
-                          {`${element.getOptions().name} - ${
-                            element.getTargetPort().getParent().getOptions()
-                              .name
-                          }:`}
-                        </Typography>
-                        <Typography variant="caption" display="block">
-                          {element.getOptions().attributes?.description}
-                        </Typography>
-                      </div>
-                    ))}
-                </div>
-              </div>
-            }
-            aria-label="description"
-            placement="right-start"
-            arrow
-          >
-            <VisibilityIcon
-              sx={descriptionIconStyle(node.options.isExpanded)}
-            />
-          </Tooltip>
-        )}
+        <NodeDescriptionIcon node={node} />
         <div
           style={{
             overflow: 'hidden',

--- a/src/view/widgets/DiagramWidget/diagram/nodes/RadicalComposedNodeWidget.jsx
+++ b/src/view/widgets/DiagramWidget/diagram/nodes/RadicalComposedNodeWidget.jsx
@@ -63,9 +63,42 @@ const RadicalComposedNodeWidget = ({
       >
         {node.options.attributes?.description && (
           <Tooltip
-            title={node.options.attributes?.description}
+            title={
+              <div>
+                <Typography variant="subtitle1">Description:</Typography>
+                <div>
+                  <Typography variant="caption">
+                    {node.options.attributes?.description}
+                  </Typography>
+                </div>
+                <Typography variant="subtitle1">Outgoing Relations:</Typography>
+                <div>
+                  {node
+                    .getLinks()
+                    .filter(
+                      (element) =>
+                        element.getSourcePort().getParent().getID() ===
+                        node.getID()
+                    )
+                    .map((element) => (
+                      <div key={element.getID()}>
+                        <Typography variant="subtitle2" display="block">
+                          {`${element.getOptions().name} - ${
+                            element.getTargetPort().getParent().getOptions()
+                              .name
+                          }:`}
+                        </Typography>
+                        <Typography variant="caption" display="block">
+                          {element.getOptions().attributes?.description}
+                        </Typography>
+                      </div>
+                    ))}
+                </div>
+              </div>
+            }
             aria-label="description"
             placement="right-start"
+            arrow
           >
             <VisibilityIcon
               sx={descriptionIconStyle(node.options.isExpanded)}

--- a/src/view/widgets/DiagramWidget/diagram/nodes/RadicalComposedNodeWidget.jsx
+++ b/src/view/widgets/DiagramWidget/diagram/nodes/RadicalComposedNodeWidget.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { PortWidget } from '@projectstorm/react-diagrams';
+import Tooltip from '@material-ui/core/Tooltip';
+import VisibilityIcon from '@material-ui/icons/Visibility';
 import Typography from '@material-ui/core/Typography';
 import AccountTreeIcon from '@material-ui/icons/AccountTree';
 import Box from '@material-ui/core/Box';
@@ -22,6 +24,13 @@ const smartPortStyle = {
   width: '16px',
   height: '16px',
 };
+
+const descriptionIconStyle = (isExpanded) => ({
+  color: isExpanded ? '#595959' : 'white',
+  position: 'absolute',
+  top: 10,
+  right: 10,
+});
 const RadicalComposedNodeWidget = ({
   node,
   engine,
@@ -52,6 +61,17 @@ const RadicalComposedNodeWidget = ({
           top: isAsymmetric ? 20 : 0,
         }}
       >
+        {node.options.attributes?.description && (
+          <Tooltip
+            title={node.options.attributes?.description}
+            aria-label="description"
+            placement="right-start"
+          >
+            <VisibilityIcon
+              sx={descriptionIconStyle(node.options.isExpanded)}
+            />
+          </Tooltip>
+        )}
         <div
           style={{
             overflow: 'hidden',

--- a/src/view/widgets/DiagramWidget/diagram/nodes/RadicalComposedNodeWidget.test.jsx
+++ b/src/view/widgets/DiagramWidget/diagram/nodes/RadicalComposedNodeWidget.test.jsx
@@ -23,6 +23,7 @@ describe('RadicalComposedNodeWidget', () => {
           isSelected: () => false,
           isLocked: () => false,
           getPorts: () => ({}),
+          getLinks: () => [],
           options: {},
         }}
         name="Gandalf"


### PR DESCRIPTION
closes #171 
As grid layers prevent proper tooltip hide/show, links were added under node description in one common tooltip
![image](https://user-images.githubusercontent.com/24255419/143777136-12ecc0b6-ef32-43a0-8e6f-5f0be34f90c8.png)
